### PR TITLE
Requested Text Updates (12/7/23)

### DIFF
--- a/src/components/Address.astro
+++ b/src/components/Address.astro
@@ -17,7 +17,7 @@ const { className } = Astro.props
     <div class="flex flex-col gap-3">
         <div class="address-item">
             <div class="address-icon"><Image alt="icon of a map pin point" src={pinpointIcon} width="60" /></div>
-            <div class="address-text">103 W. Boggstown Rd, Shelbyville, IN 46176</div>
+            <div class="address-text">103 West Boggstown Road, Shelbyville, Indiana 46176</div>
         </div>
         <div class="address-item">
             <div class="address-icon phone"><Image alt="icon of a smartphone" src={smartphoneIcon} width="44" /></div>

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -6,11 +6,11 @@
         },
         {
             "question": "How do I sign up for Medicare?",
-            "answer": "You can sign up for Medicare through the Social Security office: either via phone appointment, in person appointment, or SSA.gov. The quickest way is through the website, and we are more than happy to help you with this process."
+            "answer": "You can sign up for Medicare through the Social Security office: via phone appointment, in person appointment, or SSA.gov. The quickest way is through the website, and we are more than happy to help you with this process."
         },
         {
             "question": "Do I have to sign up for Medicare at age 65?",
-            "answer": "If you have credible group coverage either through your employment or your spouses', then no, you do not have to sign up for Medicare at age 65. If you are on Marketplace insurance, you will need to enroll in Medicare upon eligibility."
+            "answer": "If you have credible group coverage either through your employment or your spouse's, then no, you do not have to sign up for Medicare at age 65. If you are on Marketplace insurance, you will need to enroll in Medicare upon eligibility."
         },
         {
             "question": "Is there a penalty for not signing up for Medicare when I turn 65?",
@@ -22,7 +22,7 @@
         },
         {
             "question": "What is the cost of Part A and Part B?",
-            "answer": "There is no premium for Part A. The premium for Part B changes each year - it is $170.10 for 2022. If you are collecting Social Security, the Part B premium is deducted from your check. If you are not collecting Social Security, you will be billed for the premium."
+            "answer": "There is no premium for Part A. The premium for Part B changes each year. If you are collecting Social Security, the Part B premium is deducted from your check. If you are not collecting Social Security, you will be billed for the premium."
         },
         {
             "question": "Do I have to have a Part D Plan?",
@@ -38,7 +38,7 @@
         },
         {
             "question": "What is a Supplement?",
-            "answer": "A Medicare Supplement, or Medigap policy, works with original Medicare to cover out of pocket costs of health insurance. Supplements have monthly premiums and a deductible, but very little out of pocket expense"
+            "answer": "A Medicare Supplement, or Medigap policy, works with original Medicare to cover out-of-pocket costs of health insurance. Supplements have monthly premiums and a deductible, but very little out-of-pocket expense"
         },
         {
             "question": "How much life insurance do I need?",
@@ -54,7 +54,7 @@
         },
         {
             "question": "How much should I plan to pay for LTC?",
-            "answer": "Premiums can seem quite high for Long Term Care Insurance. However, when you consider that a person aged 65 today has a 70% chance of needing some type of long-term care services at a cost of $3000-$8000 per month or more, then the premiums look small in comparison.   We can work up some options for you and let you see the cost of not having the proper coverage."
+            "answer": "Premiums can seem quite high for Long Term Care Insurance. However, when you consider that a person aged 65 today has a 70% chance of needing some type of long-term care services at a cost of $3,000—$8,000 per month or more, then the premiums look small in comparison.   We can work up some options for you and let you see the cost of not having the proper coverage."
         },
         {
             "question": "What is an annuity?",
@@ -62,7 +62,7 @@
         },
         {
             "question": "Can I roll my 401k into an annuity?",
-            "answer": "Yes, you can. 401K's, 403B's and other employer retirement plans are typically considered Qualified Plans. That means that the money that was paid in was done before taxes, so the money is 'Pre-Tax'. To avoid taxation when moving money out of a Qualified Plan you must roll or transfer the funds into another Qualified plan such as a Traditional IRA. A Roth IRA would create a taxable situation, but some people are fine with that. There are many types of investment vehicles that can have the Traditional IRA designation, including annuities."
+            "answer": "Yes, you can. 401Ks, 403Bs and other employer retirement plans are typically considered Qualified Plans. That means that the money that was paid in was done before taxes, so the money is 'Pre-Tax'. To avoid taxation when moving money out of a Qualified Plan you must roll or transfer the funds into another Qualified Plan such as a Traditional IRA. A Roth IRA would create a taxable situation, but some people are fine with that. There are many types of investment vehicles that can have the Traditional IRA designation, including annuities."
         }
     ],
     "heading": {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -22,7 +22,7 @@ const links = config.links;
         <div class="flex flex-col items-start w-full gap-3">
             <div class="product-subheader !text-left">Founded in 2007, Compass Insurance Group is a powerhouse that prides itself in working with the senior community.</div>
             <p>Compass Insurance Group started in 2007 to serve the needs of the senior community.  The group’s founder, Gary Nolley, realized the market was under-served, and knew that the Medicare process was challenging for many individuals.  With so many products and companies out there, the decision-making process is often overwhelming. Gary set out to address those needs, and his commitment and knowledge has been instilled in all the agents at Compass. Compass strives to ensure its clients are informed and knowledgeable about the products which they buy – both before and after the purchase. Compass also represents companies and products of the traditional insurance and annuity variety.  Many of our agents started in these markets before joining Compass, so their knowledge and experience in these areas is immense.</p>
-            <p>In addition to specializing in the Senior Market, Compass Insurance can also help with Marketplace (ACA) insurance, life insurance, and rolling your 401k, pension, or CD’s into an annuity for your retirement. </p>
+            <p>In addition to specializing in the Senior Market, Compass Insurance can also help with Marketplace (ACA) insurance, life insurance, and rolling your 401k, pension, or CDs into an annuity for your retirement. </p>
             <p>No matter the products you are in the market for, Compass is here for you – helping you navigate the insurance maze.</p>
         </div>
         <div class="product-header text-center mx-auto">Meet the team</div>
@@ -36,7 +36,7 @@ const links = config.links;
                         <div>Gary Nolley</div>
                         <p>Founder, Agent</p>
                     </div>
-                    <p>Throughout his career, Gary has served in many roles, including district manager, trainer, and national manager. He formed Compass Insurance Group in 2007 in order to focus on serving the unique needs of the Senior population and the baby boomer generation. This specialized focus allows him to stay on top of the latest trends and products and enables him to provide the best service possible.</p>
+                    <p>Throughout his career, Gary has served in many roles, including district manager, trainer, and national manager. He formed Compass Insurance Group in 2007 in order to focus on serving the unique needs of the senior population and the baby boomer generation. This specialized focus allows him to stay on top of the latest trends and products and enables him to provide the best service possible.</p>
                 </div>
             </div>
             <div class="team-member">
@@ -65,7 +65,7 @@ const links = config.links;
             </div>
         </div>
         <Button className="w-[80%] max-w-[425px] mx-auto md:my-4 lg:my-0 md:w-full lg:w-80 lg:mx-0 lg:mt-3" href={links.contact.href}>{links.contact.buttonText}</Button>
-        <Quicklinks className="lg:hidden mb-6 mx-auto md:max-w-[700px]" showDropdown="true" />
+        <Quicklinks className="lg:hidden mb-6 mx-auto md:max-w-[700px]" showDropdown={true} />
     </div>
 </Layout>
 <style>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -47,7 +47,7 @@ const links = config.links;
         <div class="text-2xl font-bold lg:hidden">Come see us!</div>
         <div class="flex flex-col lg:flex-row gap-5 my-5 max-w-md md:max-w-xl lg:max-w-full">
             <Address />
-            <iframe src="https://maps.google.com/maps?q=103%20W.%20Boggstown%20Road%2C%20%20Shelbyville%2C%20IN%2046176&t=m&z=10&output=embed&iwloc=near" title="103 W. Boggstown Road, Shelbyville, IN 46176" class="w-full h-64 lg:h-[398px]" />
+            <iframe src="https://maps.google.com/maps?q=103%20W.%20Boggstown%20Road%2C%20%20Shelbyville%2C%20IN%2046176&t=m&z=10&output=embed&iwloc=near" title="103 West Boggstown Road, Shelbyville, IN 46176" class="w-full h-64 lg:h-[398px]" />
             <Quicklinks className="lg:hidden" showDropdown />
         </div>
     </div>

--- a/src/pages/medicare/part-a.astro
+++ b/src/pages/medicare/part-a.astro
@@ -27,7 +27,7 @@ const links = config.links;
         <p>If you’re under 65, you can get premium-free Part A if:</p>
         <ul class="flex flex-col list-disc pl-5 mb-3">
             <li>You got Social Security or Railroad Retirement Board disability benefits for 24 months.</li>
-            <li>You have End-Stage Renal Disease (Esrd) and meet certain requirements.</li>
+            <li>You have End-Stage Renal Disease (ESRD) and meet certain requirements.</li>
         </ul>
         <div class="product-subheader">Part A Premiums</div>
         <p>If you don’t qualify for premium-free Part A, you can buy Part A. People who buy Part A will pay a premium each month. That premium is determined by Medicare each year as well as how long they or their spouse worked and paid Medicare taxes. If you choose NOT to buy Part A, you can still buy Part B.</p>


### PR DESCRIPTION
https://nblakey.github.io/compass-insurance/medicare/part-a/
- "End-Stage Renal Disease (Esrd)" - acronym should be capitalized

https://nblakey.github.io/compass-insurance/about/
- "CD’s " - no apostrophe (the CD does not own anything)
- "unique needs of the Senior population" - not sure "senior" needs to be capitalized here

https://nblakey.github.io/compass-insurance/faq/
- "You can sign up for Medicare through the Social Security office: either via phone appointment, in person appointment, or SSA.gov." - remove "either" (it is only used when you have two to choose from)
- "through your employment or your spouses' " - the apostrophe should be before the "s" (unless they have multiple spouses)
- The premium for Part B changes each year - it is $170.10 for 2022. - Consider removing this. Things tied to durations ("In business for more than 15 years...") are to be avoided because you never update the website as much as you should. Same goes with dated data.
- "original Medicare to cover out of pocket costs" - in other places you have hyphens in "out-of-pocket"
- "Supplements have monthly premiums and a deductible, but very little out of pocket expense" - same
- "at a cost of $3000-$8000 per month" - consider adding commas to the dollar amounts for legibility
- "401K's, 403B's and other employer retirement" - no apostrophes (they do not own anything)
- "money out of a Qualified Plan you must roll or transfer the funds into another Qualified plan" - should second "plan" also be capitalized?

https://nblakey.github.io/compass-insurance/contact/
- The Email Us button auto-fills Ashley's email address. Is this what you want versus an "info@" that can go to Carrie or both of you or something else?
- "103 W. Boggstown Rd, Shelbyville, IN 46176" - consider spelling out "West", "Road", and "Indiana" (same on the main page)