### PR TITLE
add background blur to headline for large viewports

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ import Testimonials from '../components/Testimonials.tsx';
 			<div class="max-w-[1200px] mx-auto relative z-30">
 				<div class="flex flex-col gap-2 lg:gap-3 xl:gap-4 items-center text-center py-6 lg:py-8 xl:py-10 lg:pl-4 xl:pt-12 lg:items-start">
 					<div class="font-normal text-base md:text-lg lg:text-2xl xl:text-3xl">Welcome to Compass Insurance Group</div>
-					<div class="font-bold text-xl md:text-2xl lg:text-3xl xl:text-4xl">Family-Owned. Central Indiana Focused. Here for You.</div>
+					<div class="font-bold text-xl md:text-2xl lg:text-3xl lg:pr-3 lg:py-1 lg:bg-[#ffffff59] lg:rounded-md lg:backdrop-blur-[2px] lg:backdrop-saturate-100 xl:text-4xl">Family-Owned. Central Indiana Focused. Here for You.</div>
 				</div>
 				<div class="lg:py-8 lg:px-4">
 					<div class="text-sm font-bold text-center lg:text-left mb-6 md:text-base lg:text-xl">Select a product for more information</div>


### PR DESCRIPTION
Trying to preserve readability in spite of a darker hero image.

<img width="1200" height="539" alt="SCR-20250905-mzsg" src="https://github.com/user-attachments/assets/20abe7e8-a7c2-47e5-8f69-9fb9249232a0" />
